### PR TITLE
Tweak logging when running with '-df'

### DIFF
--- a/vcfgl.cpp
+++ b/vcfgl.cpp
@@ -144,7 +144,6 @@ int setval(bcf_hdr_t *out_hdr,bcf1_t *out_bcf,int nSamples,double errate,double 
 
 		if(mps_depths!=NULL){
 			n_sim_reads=Poisson(mps_depths[sample_i]);
-			fprintf(stderr, "\nIndividual %d mean per-site depth is set to %f\n", sample_i,mps_depths[sample_i]);
 		}else{
 			n_sim_reads=Poisson(mps_depth);
 		}
@@ -388,6 +387,11 @@ int main(int argc, char **argv) {
 
 		if(in_mps_depths!=NULL){
 			mps_depths=read_depthsFile(in_mps_depths, nSamples);
+
+			fprintf(stderr, "\n");
+			for (int sample_i=0; sample_i<nSamples; sample_i++) {
+				fprintf(stderr, "Individual %d mean per-site depth is set to %f\n", sample_i,mps_depths[sample_i]);
+			}
 		}
 
 


### PR DESCRIPTION
The individual depths were printed per site, reading to large log outputs. Now, they are printed once during initialization instead.

This is mainly to make it a bit easier to use vcfgl at large scale in, say, a pipeline with automated logging. I just cleaned up 2.5T of logs with repeated individual depths, for instance. In addition, I suspect printing this often may have non-negligible overhead, though I didn't look too much into this.